### PR TITLE
Pull request: Update Japanese Translation on 14 Sep, 2021

### DIFF
--- a/1.2/Languages/Japanese/DefInjected/WorkGiverDef/WorkGivers.xml
+++ b/1.2/Languages/Japanese/DefInjected/WorkGiverDef/WorkGivers.xml
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- Nursing -->
+
+  <JS_NurseRescue.label>倒れた同盟者を救助して\nベッドに運ぶ</JS_NurseRescue.label>
+  <JS_NurseRescue.verb>の救助</JS_NurseRescue.verb>
+  <JS_NurseRescue.gerund>の救助をする</JS_NurseRescue.gerund>
+
+  <JS_NurseFeedHumanlikes.label>患者に食事を与える</JS_NurseFeedHumanlikes.label>
+  <JS_NurseFeedHumanlikes.verb>に食事を与える</JS_NurseFeedHumanlikes.verb>
+  <JS_NurseFeedHumanlikes.gerund>に食事を与える</JS_NurseFeedHumanlikes.gerund>
+
+  <JS_NurseFeedAnimals.label>動物にエサを与える</JS_NurseFeedAnimals.label>
+  <JS_NurseFeedAnimals.verb>にエサを与える</JS_NurseFeedAnimals.verb>
+  <JS_NurseFeedAnimals.gerund>にエサを与える</JS_NurseFeedAnimals.gerund>
+
+  <JS_NurseToBedToOperate.label>手術をするため患者を\nベッドに運ぶ</JS_NurseToBedToOperate.label>
+  <JS_NurseToBedToOperate.verb>を手術する</JS_NurseToBedToOperate.verb>
+  <JS_NurseToBedToOperate.gerund>を手術する</JS_NurseToBedToOperate.gerund>
+
+  <JS_NurseVisitSickPawn.label>病状の容態を確認する</JS_NurseVisitSickPawn.label>
+  <JS_NurseVisitSickPawn.verb>を見舞う</JS_NurseVisitSickPawn.verb>
+  <JS_NurseVisitSickPawn.gerund>を見舞いする</JS_NurseVisitSickPawn.gerund>
+
+
+  <!-- Feeding -->
+
+  <JS_FeederFeedHumanlikes.label>患者に食事を運ぶ</JS_FeederFeedHumanlikes.label>
+  <JS_FeederFeedHumanlikes.verb>に食事を運ぶ</JS_FeederFeedHumanlikes.verb>
+  <JS_FeederFeedHumanlikes.gerund>に食事を運ぶ</JS_FeederFeedHumanlikes.gerund>
+
+  <JS_FeederFeedAnimals.label>動物に給餌する</JS_FeederFeedAnimals.label>
+  <JS_FeederFeedAnimals.verb>を給餌する</JS_FeederFeedAnimals.verb>
+  <JS_FeederFeedAnimals.gerund>を給餌する</JS_FeederFeedAnimals.gerund>
+
+
+  <!-- Butcher -->
+  
+  <JS_ButcherSlaughter.label>動物を屠殺</JS_ButcherSlaughter.label>
+  <JS_ButcherSlaughter.verb>を屠殺</JS_ButcherSlaughter.verb>
+  <JS_ButcherSlaughter.gerund>を屠殺する</JS_ButcherSlaughter.gerund>
+
+  <JS_ButcherDoExecution.label>囚人を処刑する</JS_ButcherDoExecution.label>
+  <JS_ButcherDoExecution.verb>を処刑する</JS_ButcherDoExecution.verb>
+  <JS_ButcherDoExecution.gerund>を処刑する</JS_ButcherDoExecution.gerund>
+  
+  
+  <!-- Mortician -->
+  
+  <JS_MorticianHaulCorpses.label>運搬</JS_MorticianHaulCorpses.label>
+  <JS_MorticianHaulCorpses.verb>を運ぶ</JS_MorticianHaulCorpses.verb>
+  <JS_MorticianHaulCorpses.gerund>を運搬する</JS_MorticianHaulCorpses.gerund>
+
+
+  <!-- Preparing -->
+
+  <JS_PrepareFrames.label>材料を骨組みに運ぶ</JS_PrepareFrames.label>
+  <JS_PrepareFrames.verb>材料を届ける</JS_PrepareFrames.verb>
+  <JS_PrepareFrames.gerund>を従事する</JS_PrepareFrames.gerund>
+
+  <JS_PrepareBlueprints.label>設計に取り掛かる</JS_PrepareBlueprints.label>
+  <JS_PrepareBlueprints.verb>に取りかかる</JS_PrepareBlueprints.verb>
+  <JS_PrepareBlueprints.gerund>を従事する</JS_PrepareBlueprints.gerund>
+
+
+</LanguageData>

--- a/1.2/Languages/Japanese/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/1.2/Languages/Japanese/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -1,0 +1,214 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <!-- Surgeon -->
+
+  <Surgeon.label>手術</Surgeon.label>
+  <Surgeon.description>手術医はヒューマノイドや動物に手術を施します。</Surgeon.description>
+  <Surgeon.labelShort>医者</Surgeon.labelShort>
+  <Surgeon.pawnLabel>手術医</Surgeon.pawnLabel>
+  <Surgeon.gerundLabel>手術</Surgeon.gerundLabel>
+  <Surgeon.verb>処置</Surgeon.verb>
+
+
+  <!-- Nursing -->
+
+  <Nursing.label>看護</Nursing.label>
+  <Nursing.description>看護師は患者への給仕や容態の確認、患者の移動によって医師を支援します。</Nursing.description>
+  <Nursing.labelShort>看護師</Nursing.labelShort>
+  <Nursing.pawnLabel>看護師</Nursing.pawnLabel>
+  <Nursing.gerundLabel>看護</Nursing.gerundLabel>
+  <Nursing.verb>看護</Nursing.verb>
+
+
+  <!-- Feeding -->
+
+  <Feeding.label>給仕</Feeding.label>
+  <Feeding.description>食事係は囚人とベッドの病人に食事を運びます。</Feeding.description>
+  <Feeding.labelShort>給仕</Feeding.labelShort>
+  <Feeding.pawnLabel>食事係</Feeding.pawnLabel>
+  <Feeding.gerundLabel>給仕</Feeding.gerundLabel>
+  <Feeding.verb>給仕</Feeding.verb>
+
+
+  <!-- Rearming -->
+
+  <Rearming.label>罠師</Rearming.label>
+  <Rearming.description>罠師は使用済の罠を仕掛け直して再設置します。</Rearming.description>
+  <Rearming.labelShort>罠師</Rearming.labelShort>
+  <Rearming.pawnLabel>罠師</Rearming.pawnLabel>
+  <Rearming.gerundLabel>再設置</Rearming.gerundLabel>
+  <Rearming.verb>再設置</Rearming.verb>
+
+
+  <!-- Refueling -->
+
+  <Refueling.label>給油</Refueling.label>
+  <Refueling.description>給油係は燃料で動くものに燃料を補給します。</Refueling.description>
+  <Refueling.labelShort>給油係</Refueling.labelShort>
+  <Refueling.pawnLabel>給油係</Refueling.pawnLabel>
+  <Refueling.gerundLabel>給油</Refueling.gerundLabel>
+  <Refueling.verb>給油</Refueling.verb>
+
+
+  <!-- Taming -->
+
+  <Taming.label>調教</Taming.label>
+  <Taming.description>調教師は野生の動物を飼い慣らします。</Taming.description>
+  <Taming.labelShort>調教</Taming.labelShort>
+  <Taming.pawnLabel>調教師</Taming.pawnLabel>
+  <Taming.gerundLabel>調教</Taming.gerundLabel>
+  <Taming.verb>調教</Taming.verb>
+
+
+  <!-- Training -->
+
+  <Training.label>訓練</Training.label>
+  <Training.description>訓練師は調教済の家畜を訓練します。</Training.description>
+  <Training.labelShort>訓練</Training.labelShort>
+  <Training.pawnLabel>訓練師</Training.pawnLabel>
+  <Training.gerundLabel>訓練</Training.gerundLabel>
+  <Training.verb>訓練</Training.verb>
+
+
+  <!-- Butcher -->
+
+  <Butcher.label>屠殺</Butcher.label>
+  <Butcher.description>肉屋は解体して精肉したりペットフードを作成します。</Butcher.description>
+  <Butcher.labelShort>屠殺</Butcher.labelShort>
+  <Butcher.pawnLabel>肉屋</Butcher.pawnLabel>
+  <Butcher.gerundLabel>屠殺</Butcher.gerundLabel>
+  <Butcher.verb>屠殺</Butcher.verb>
+
+
+  <!-- Brewing -->
+
+  <Brewing.label>醸造</Brewing.label>
+  <Brewing.description>醸造者はホップから麦汁を作り、樽を満たしてお酒を造り空にします。</Brewing.description>
+  <Brewing.labelShort>醸造</Brewing.labelShort>
+  <Brewing.pawnLabel>醸造者</Brewing.pawnLabel>
+  <Brewing.gerundLabel>醸造</Brewing.gerundLabel>
+  <Brewing.verb>醸造</Brewing.verb>
+
+
+  <!-- Repairing -->
+
+  <Repairing.label>修理</Repairing.label>
+  <Repairing.description>修理屋は損傷を受けた建物や物品を修理します。</Repairing.description>
+  <Repairing.labelShort>修理</Repairing.labelShort>
+  <Repairing.pawnLabel>修理屋</Repairing.pawnLabel>
+  <Repairing.gerundLabel>修理</Repairing.gerundLabel>
+  <Repairing.verb>修理</Repairing.verb>
+
+
+  <!-- Demolition -->
+
+  <Demolition.label>解体</Demolition.label>
+  <Demolition.description>解体屋は建物や物品を取り外したり解体します。</Demolition.description>
+  <Demolition.labelShort>解体</Demolition.labelShort>
+  <Demolition.pawnLabel>解体屋</Demolition.pawnLabel>
+  <Demolition.gerundLabel>解体</Demolition.gerundLabel>
+  <Demolition.verb>解体</Demolition.verb>
+
+
+  <!-- Harvesting -->
+
+  <Harvesting.label>収穫</Harvesting.label>
+  <Harvesting.description>収穫者は作物を収穫します。</Harvesting.description>
+  <Harvesting.labelShort>収穫</Harvesting.labelShort>
+  <Harvesting.pawnLabel>収穫者</Harvesting.pawnLabel>
+  <Harvesting.gerundLabel>収穫</Harvesting.gerundLabel>
+  <Harvesting.verb>収穫</Harvesting.verb>
+
+
+  <!-- Drilling -->
+
+  <Drilling.label>掘削</Drilling.label>
+  <Drilling.description>鉱員は掘削ドリルを使用して資源を採掘します。</Drilling.description>
+  <Drilling.labelShort>掘削</Drilling.labelShort>
+  <Drilling.pawnLabel>鉱員</Drilling.pawnLabel>
+  <Drilling.gerundLabel>掘削</Drilling.gerundLabel>
+  <Drilling.verb>掘削</Drilling.verb>
+
+
+  <!-- Drugs -->
+
+  <Drugs.label>調薬</Drugs.label>
+  <Drugs.description>薬剤師は医薬品やドラッグを作成します。</Drugs.description>
+  <Drugs.labelShort>調薬</Drugs.labelShort>
+  <Drugs.pawnLabel>薬剤師</Drugs.pawnLabel>
+  <Drugs.gerundLabel>調薬</Drugs.gerundLabel>
+  <Drugs.verb>調薬</Drugs.verb>
+
+
+  <!-- Assemble -->
+
+  <Assemble.label>組立</Assemble.label>
+  <Assemble.description>組立工はコンポーネント組立台で組立を行います。</Assemble.description>
+  <Assemble.labelShort>組立</Assemble.labelShort>
+  <Assemble.pawnLabel>組立工</Assemble.pawnLabel>
+  <Assemble.gerundLabel>組立</Assemble.gerundLabel>
+  <Assemble.verb>組立</Assemble.verb>
+
+
+  <!-- Refine -->
+
+  <Refining.label>精製</Refining.label>
+  <Refining.description>科学者は製油施設で化学物質を液化燃料に変えます。</Refining.description>
+  <Refining.labelShort>精製</Refining.labelShort>
+  <Refining.pawnLabel>科学者</Refining.pawnLabel>
+  <Refining.gerundLabel>精製</Refining.gerundLabel>
+  <Refining.verb>精製</Refining.verb>
+
+
+  <!-- Stonecutting -->
+
+  <Stonecutting.label>石切</Stonecutting.label>
+  <Stonecutting.description>石工は岩の塊を石材ブロックに切り出します。</Stonecutting.description>
+  <Stonecutting.labelShort>石切り</Stonecutting.labelShort>
+  <Stonecutting.pawnLabel>石工</Stonecutting.pawnLabel>
+  <Stonecutting.gerundLabel>石切り</Stonecutting.gerundLabel>
+  <Stonecutting.verb>石切り</Stonecutting.verb>
+
+
+  <!-- Smelting -->
+
+  <Smelting.label>製錬</Smelting.label>
+  <Smelting.description>製錬工は岩の塊やその他の鉄くずなどから使用可能な金属を抽出します。</Smelting.description>
+  <Smelting.labelShort>製錬</Smelting.labelShort>
+  <Smelting.pawnLabel>製錬工</Smelting.pawnLabel>
+  <Smelting.gerundLabel>金属抽出</Smelting.gerundLabel>
+  <Smelting.verb>製錬</Smelting.verb>
+
+
+  <!-- Preparing -->
+
+  <Preparing.label>運搬</Preparing.label>
+  <Preparing.description>運搬人は青写真と未完成の建物に建築材料を運びます。</Preparing.description>
+  <Preparing.labelShort>運搬</Preparing.labelShort>
+  <Preparing.pawnLabel>運搬人</Preparing.pawnLabel>
+  <Preparing.gerundLabel>運搬</Preparing.gerundLabel>
+  <Preparing.verb>運搬</Preparing.verb>
+
+
+  <!-- Loading -->
+
+  <Loading.label>荷積</Loading.label>
+  <Loading.description>作業者は輸送用ポッドやキャラバンの積み降ろしを行います。</Loading.description>
+  <Loading.labelShort>荷積</Loading.labelShort>
+  <Loading.pawnLabel>作業者</Loading.pawnLabel>
+  <Loading.gerundLabel>荷積み</Loading.gerundLabel>
+  <Loading.verb>荷積</Loading.verb>
+
+
+  <!-- Mortican -->
+
+  <Mortician.label>葬儀</Mortician.label>
+  <Mortician.description>葬儀屋は埋葬したり死体を焼却したりします。</Mortician.description>
+  <Mortician.labelShort>埋葬</Mortician.labelShort>
+  <Mortician.pawnLabel>葬儀屋</Mortician.pawnLabel>
+  <Mortician.gerundLabel>埋葬</Mortician.gerundLabel>
+  <Mortician.verb>埋葬</Mortician.verb>
+
+
+</LanguageData>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<loadFolders>
+  <v1.0 />
+  <v1.1>
+    <li>Common</li>
+    <li>1.2</li>
+  </v1.1>
+  <v1.2>
+    <li>Common</li>
+    <li>1.2</li>
+  </v1.2>
+  <v1.3>
+    <li>Common</li>
+    <li>1.3</li>
+  </v1.3>
+</loadFolders>


### PR DESCRIPTION
**This is only a suggestion, not a valid pull request.**
Merge it if you really need it.

- add 1.2\Languages\Japanese
- add LoadFolders.xml

Since the 1.3 version is applied to the Japanese translation of the 1.1-1.2 version and a translation error occurs, use the folder specification by LoadFolders.xml to separate the translation between 1.2 before and 1.3.

Note:
There are no jobs such as Fire or Patient in the 1.2 version of WorkTypes.xml. This causes translation errors when used in 1.2.